### PR TITLE
Unbreak support for OpenBSD.

### DIFF
--- a/osext_procfs.go
+++ b/osext_procfs.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux netbsd openbsd solaris dragonfly
+// +build linux netbsd solaris dragonfly
 
 package osext
 
@@ -27,7 +27,7 @@ func executable() (string, error) {
 		return execpath, nil
 	case "netbsd":
 		return os.Readlink("/proc/curproc/exe")
-	case "openbsd", "dragonfly":
+	case "dragonfly":
 		return os.Readlink("/proc/curproc/file")
 	case "solaris":
 		return os.Readlink(fmt.Sprintf("/proc/%d/path/a.out", os.Getpid()))

--- a/osext_sysctl.go
+++ b/osext_sysctl.go
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin freebsd
+// +build darwin freebsd openbsd
 
 package osext
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"syscall"
@@ -23,6 +24,8 @@ func executable() (string, error) {
 		mib = [4]int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1}
 	case "darwin":
 		mib = [4]int32{1 /* CTL_KERN */, 38 /* KERN_PROCARGS */, int32(os.Getpid()), -1}
+	case "openbsd":
+		mib = [4]int32{1 /* CTL_KERN */, 55 /* KERN_PROC_ARGS */, int32(os.Getpid()), 1 /* KERN_PROC_ARGV */}
 	}
 
 	n := uintptr(0)
@@ -42,14 +45,58 @@ func executable() (string, error) {
 	if n == 0 { // This shouldn't happen.
 		return "", nil
 	}
-	for i, v := range buf {
-		if v == 0 {
-			buf = buf[:i]
-			break
+
+	var execPath string
+	switch runtime.GOOS {
+	case "openbsd":
+		// buf now contains **argv, with pointers to each of the C-style
+		// NULL terminated arguments.
+		var args []string
+		argv := uintptr(unsafe.Pointer(&buf[0]))
+		Loop:
+			for {
+				argp := *(**[1<<20]byte)(unsafe.Pointer(argv))
+				if argp == nil {
+					break
+				}
+				for i := 0; uintptr(i) < n; i++ {
+					// we don't want the full arguments list
+					if string(argp[i]) == " " {
+						break Loop
+					}
+					if argp[i] != 0 {
+						continue
+					}
+					args = append(args, string(argp[:i]))
+					n -= uintptr(i)
+					break
+				}
+				if n < unsafe.Sizeof(argv) {
+					break
+				}
+				argv += unsafe.Sizeof(argv)
+				n -= unsafe.Sizeof(argv)
+			}
+		execPath = args[0]
+		// There is no canonical way to get an executable path on
+		// OpenBSD, so check PATH in case we are called directly
+		if execPath[0] != '/' && execPath[0] != '.' {
+			execIsInPath, err := exec.LookPath(execPath)
+			if err == nil {
+				execPath = execIsInPath
+			}
 		}
+	default:
+		for i, v := range buf {
+			if v == 0 {
+				buf = buf[:i]
+				break
+			}
+		}
+		execPath = string(buf)
 	}
+
 	var err error
-	execPath := string(buf)
 	// execPath will not be empty due to above checks.
 	// Try to get the absolute path if the execPath is not rooted.
 	if execPath[0] != '/' {

--- a/osext_test.go
+++ b/osext_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux freebsd netbsd windows
+// +build darwin linux freebsd netbsd windows openbsd
 
 package osext
 


### PR DESCRIPTION
OpenBSD does not have procfs and there's no canonical way to get an executable
path so this implementation is a best effort.

Let's restart with a patch for osext_sysctl as agreed.
I am opened for discussion but you need to realize that it's really tricky to make this work on OpenBSD compared to other platforms. Hopefully my last pull request answered some of your questions, otherwise feel free to ask me.

Thanks ;-)
