### PR TITLE
osext: openbsd is considered broken in go1.8 for Executable

### DIFF
--- a/osext_go18.go
+++ b/osext_go18.go
@@ -1,4 +1,4 @@
-//+build go1.8
+//+build go1.8,!openbsd
 
 package osext
 

--- a/osext_sysctl.go
+++ b/osext_sysctl.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !go1.8,darwin !go1.8,freebsd !go1.8,openbsd
+// +build !go1.8,darwin !go1.8,freebsd openbsd
 
 package osext
 


### PR DESCRIPTION
For now continue to use internal logic for openbsd.

Fixes #22