### PR TITLE
Add android support for proc filesystems

### DIFF
--- a/osext_procfs.go
+++ b/osext_procfs.go
@@ -16,7 +16,7 @@ import (
 
 func executable() (string, error) {
 	switch runtime.GOOS {
-	case "linux","android":
+	case "linux", "android":
 		const deletedTag = " (deleted)"
 		execpath, err := os.Readlink("/proc/self/exe")
 		if err != nil {

--- a/osext_procfs.go
+++ b/osext_procfs.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !go1.8,linux !go1.8,netbsd !go1.8,solaris !go1.8,dragonfly
+// +build !go1.8,android !go1.8,linux !go1.8,netbsd !go1.8,solaris !go1.8,dragonfly
 
 package osext
 
@@ -16,7 +16,7 @@ import (
 
 func executable() (string, error) {
 	switch runtime.GOOS {
-	case "linux":
+	case "linux","android":
 		const deletedTag = " (deleted)"
 		execpath, err := os.Readlink("/proc/self/exe")
 		if err != nil {


### PR DESCRIPTION
Added android support to the procfs file. Android uses the same proc filesystem as linux under the hood, and so they should be compatible.