### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/osext.go
+++ b/osext.go
@@ -21,7 +21,7 @@ func Executable() (string, error) {
 	return cx, ce
 }
 
-// Returns same path as Executable, returns just the folder
+// ExecutableFolder returns same path as Executable, returns just the folder
 // path. Excludes the executable name and any trailing slash.
 func ExecutableFolder() (string, error) {
 	p, err := Executable()


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._
